### PR TITLE
Cleanup algebra solvers

### DIFF
--- a/stan/math/prim/functor.hpp
+++ b/stan/math/prim/functor.hpp
@@ -5,6 +5,8 @@
 #include <stan/math/prim/functor/apply_scalar_unary.hpp>
 #include <stan/math/prim/functor/apply_scalar_binary.hpp>
 #include <stan/math/prim/functor/apply_vector_unary.hpp>
+#include <stan/math/prim/functor/algebra_solver_fp.hpp>
+#include <stan/math/prim/functor/algebra_solver_powell.hpp>
 #include <stan/math/prim/functor/coupled_ode_system.hpp>
 #include <stan/math/prim/functor/finite_diff_gradient.hpp>
 #include <stan/math/prim/functor/finite_diff_gradient_auto.hpp>

--- a/stan/math/prim/functor/algebra_solver_fp.hpp
+++ b/stan/math/prim/functor/algebra_solver_fp.hpp
@@ -1,0 +1,307 @@
+#ifndef STAN_MATH_PRIM_FUNCTOR_FP_SOLVER_HPP
+#define STAN_MATH_PRIM_FUNCTOR_FP_SOLVER_HPP
+
+#include <stan/math/prim/meta.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/fun/eval.hpp>
+#include <stan/math/prim/functor/apply.hpp>
+#include <stan/math/prim/functor/algebra_solver_adapter.hpp>
+#include <kinsol/kinsol.h>
+#include <sunmatrix/sunmatrix_dense.h>
+#include <sunlinsol/sunlinsol_dense.h>
+#include <nvector/nvector_serial.h>
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * KINSOL algebraic system data holder that handles
+ * construction & destruction of SUNDIALS data, as well as
+ * auxiliary data that will be used for functor evaluation.
+ *
+ * @tparam F functor type for system function.
+ * @tparam T_u type of scaling vector for unknowns. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ * @tparam T_f type of scaling vector for residual. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ * @tparam Args types of additional parameters to the equation system functor.
+ */
+template <typename F, typename T_u, typename T_f, typename... Args>
+struct KinsolFixedPointEnv {
+  /** RHS functor. */
+  const F& f_;
+  /** system size */
+  const size_t N_;
+  /** message stream */
+  std::ostream* msgs_;
+  /** arguments and parameters */
+  std::tuple<const Args&...> args_tuple_;
+  /** KINSOL memory block */
+  void* mem_;
+  /** NVECTOR for unknowns */
+  N_Vector nv_x_;
+  /** NVECTOR for scaling u */
+  N_Vector nv_u_scal_;
+  /** NVECTOR for scaling f */
+  N_Vector nv_f_scal_;
+
+  KinsolFixedPointEnv(const F& f, const Eigen::MatrixXd x,
+                      const std::vector<T_u>& u_scale,
+                      const std::vector<T_f>& f_scale, std::ostream* const msgs,
+                      const Args&... args)
+      : f_(f),
+        N_(x.size()),
+        msgs_(msgs),
+        args_tuple_(args...),
+        mem_(KINCreate()),
+        nv_x_(N_VNew_Serial(N_)),
+        nv_u_scal_(N_VNew_Serial(N_)),
+        nv_f_scal_(N_VNew_Serial(N_)) {
+    for (int i = 0; i < N_; ++i) {
+      NV_Ith_S(nv_x_, i) = stan::math::value_of(x(i));
+    }
+    for (int i = 0; i < N_; ++i) {
+      NV_Ith_S(nv_u_scal_, i) = stan::math::value_of(u_scale[i]);
+    }
+    for (int i = 0; i < N_; ++i) {
+      NV_Ith_S(nv_f_scal_, i) = stan::math::value_of(f_scale[i]);
+    }
+  }
+
+  ~KinsolFixedPointEnv() {
+    N_VDestroy_Serial(nv_x_);
+    N_VDestroy_Serial(nv_u_scal_);
+    N_VDestroy_Serial(nv_f_scal_);
+    KINFree(&mem_);
+  }
+
+  /** Implements the user-defined function passed to KINSOL. */
+  static int kinsol_f_system(const N_Vector x, const N_Vector f,
+                             void* const user_data) {
+    auto g = static_cast<const KinsolFixedPointEnv<F, T_u, T_f, Args...>*>(
+        user_data);
+    Eigen::Map<Eigen::VectorXd>(N_VGetArrayPointer(f), g->N_) = apply(
+        [&x, &g](const auto&... args) {
+          return g->f_(Eigen::Map<Eigen::VectorXd>(NV_DATA_S(x), g->N_), g->msgs_, args...);
+        },
+        g->args_tuple_);
+    return 0;
+  }
+};
+
+/**
+ * Private interface for solving fixed point problems using KINSOL. Users should
+ * call the KINSOL fixed point solver through `algebra_solver_fp` or
+ * `algebra_solver_fp_impl`.
+ *
+ * @tparam F type of the equation system functor f
+ * @tparam T_u type of scaling vector for unknowns. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ * @tparam T_f type of scaling vector for residual. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ * @param x initial point and final solution.
+ * @param env KINSOL solution environment
+ * @param f_tol Function tolerance
+ * @param max_num_steps max nb. of iterations.
+ */
+template <typename F, typename T, typename T_u, typename T_f, typename... Args,
+          require_eigen_vector_t<T>* = nullptr>
+Eigen::VectorXd kinsol_solve_fp(const F& f, const T& x,
+                                const double function_tolerance,
+                                const double max_num_steps,
+                                const std::vector<T_u>& u_scale,
+                                const std::vector<T_f>& f_scale,
+                                std::ostream* const msgs, const Args&... args) {
+  KinsolFixedPointEnv<F, T_u, T_f, Args...> env(f, x, u_scale, f_scale, msgs,
+                                                args...);
+  const int N = x.size();
+  constexpr int default_anderson_depth = 4;
+  const int anderson_depth = std::min(N, default_anderson_depth);
+
+  check_flag_sundials(KINSetNumMaxIters(env.mem_, max_num_steps),
+                      "KINSetNumMaxIters");
+  check_flag_sundials(KINSetMAA(env.mem_, anderson_depth), "KINSetMAA");
+  check_flag_sundials(KINInit(env.mem_, &env.kinsol_f_system, env.nv_x_),
+                      "KINInit");
+  check_flag_sundials(KINSetFuncNormTol(env.mem_, function_tolerance),
+                      "KINSetFuncNormTol");
+  check_flag_sundials(KINSetUserData(env.mem_, static_cast<void*>(&env)),
+                      "KINSetUserData");
+
+  check_flag_kinsol(
+      KINSol(env.mem_, env.nv_x_, KIN_FP, env.nv_u_scal_, env.nv_f_scal_),
+      max_num_steps);
+
+  return Eigen::Map<Eigen::VectorXd>(N_VGetArrayPointer(env.nv_x_), N);
+}
+
+/**
+ * Return a fixed pointer to the specified system of algebraic
+ * equations of form
+ * \[
+ *   x = F(x; theta)
+ * \]
+ * given an initial guess \(x\), and parameters \(theta\) and data. Use the
+ * KINSOL solver from the SUNDIALS suite.
+ *
+ * The user can also specify the scaling controls, the function
+ * tolerance, and the maximum number of steps.
+ *
+ * This function is overloaded to handle both constant and var-type parameters.
+ * This overload handles var parameters, and checks the input, calls the
+ * algebraic solver, and appropriately handles derivative propagation through
+ * the `reverse_pass_callback`.
+ *
+ * @tparam F type of equation system function.
+ * @tparam T type of initial guess vector.
+ * @tparam T_u type of scaling vector for unknowns. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ * @tparam T_f type of scaling vector for residual. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ *
+ * @param[in] f functor that evaluated the system of equations.
+ * @param[in] x vector of starting values.
+ * @param[in, out] msgs the print stream for warning messages.
+ * @param[in] u_scale diagonal scaling matrix elements \(Du\)
+ *                    such that \(Du x\) has all components roughly the same
+ *                    magnitude when \(x\) is close to a solution.
+ *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
+ * @param[in] f_scale diagonal scaling matrix elements such
+ *                    that \(Df (x - f(x))\) has all components roughly the same
+ *                    magnitude when \(x\) is not too close to a solution.
+ *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
+ * @param[in] function_tolerance Function-norm stopping tolerance.
+ * @param[in] max_num_steps maximum number of function evaluations.
+ * @param[in] args additional parameters to the equation system functor.
+ * @pre f returns finite values when passed any value of x and the given args.
+ * @throw <code>std::invalid_argument</code> if x has size zero.
+ * @throw <code>std::invalid_argument</code> if x has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if scaled_step_size is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
+ * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
+ * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
+ */
+template <typename F, typename T, typename T_u, typename T_f, typename... Args,
+          require_eigen_vector_t<T>* = nullptr,
+          require_all_st_arithmetic<Args...>* = nullptr>
+Eigen::VectorXd algebra_solver_fp_impl(const F& f, const T& x,
+                                       std::ostream* const msgs,
+                                       const std::vector<T_u>& u_scale,
+                                       const std::vector<T_f>& f_scale,
+                                       const double function_tolerance,
+                                       const int max_num_steps,
+                                       const Args&... args) {
+  const auto& x_ref = to_ref(value_of(x));
+
+  check_nonzero_size("algebra_solver_fp", "initial guess", x_ref);
+  check_finite("algebra_solver_fp", "initial guess", x_ref);
+  check_nonnegative("algebra_solver_fp", "u_scale", u_scale);
+  check_nonnegative("algebra_solver_fp", "f_scale", f_scale);
+  check_nonnegative("algebra_solver_fp", "function_tolerance",
+                    function_tolerance);
+  check_positive("algebra_solver_fp", "max_num_steps", max_num_steps);
+  check_matching_sizes("algebra_solver_fp", "the algebraic system's output",
+                       value_of(f(x_ref, msgs, args...)),
+                       "the vector of unknowns, x,", x_ref);
+
+  return kinsol_solve_fp(f, x_ref, function_tolerance, max_num_steps, u_scale,
+                         f_scale, msgs, args...);
+}
+
+/**
+ * Return a fixed pointer to the specified system of algebraic
+ * equations of form
+ *
+ * x = F(x; theta)
+ *
+ * given an initial guess x, and parameters theta and data. Use the
+ * KINSOL solver from the SUNDIALS suite.
+ *
+ * The user can also specify the scaling controls, the function
+ * tolerance, and the maximum number of steps.
+ *
+ * Signature to maintain backward compatibility, will be removed
+ * in the future.
+ *
+ * @tparam F type of equation system function.
+ * @tparam T type of initial guess vector. The final solution
+ *           type doesn't depend on initial guess type,
+ *           but we allow initial guess to be either data or param.
+ * @tparam T_u type of scaling vector for unknowns. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ * @tparam T_f type of scaling vector for residual. We allow
+ *             it to be @c var because scaling could be parameter
+ *             dependent. Internally these params are converted to data
+ *             because scaling is applied.
+ *
+ * @param[in] f Functor that evaluated the system of equations.
+ * @param[in] x Vector of starting values.
+ * @param[in] y Parameter vector for the equation system. The function
+ *            is overloaded to treat y as a vector of doubles or of a
+ *            a template type T.
+ * @param[in] dat Continuous data vector for the equation system.
+ * @param[in] dat_int Integer data vector for the equation system.
+ * @param[in, out] msgs The print stream for warning messages.
+ * @param[in] u_scale diagonal scaling matrix elements Du
+ *                    such that Du*x has all components roughly the same
+ *                    magnitude when x is close to a solution.
+ *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
+ * @param[in] f_scale diagonal scaling matrix elements such
+ *                    that Df*(x-f(x)) has all components roughly the same
+ *                    magnitude when x is not too close to a solution.
+ *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
+ * @param[in] f_tol Function-norm stopping tolerance.
+ * @param[in] max_num_steps maximum number of function evaluations.
+ * @pre f returns finite values when passed any value of x and the given y, dat,
+ *        and dat_int.
+ * @throw <code>std::invalid_argument</code> if x has size zero.
+ * @throw <code>std::invalid_argument</code> if x has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if dat_int has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if scaled_step_size is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
+ * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
+ * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
+ */
+template <typename F, typename T1, typename T2, typename T_u, typename T_f,
+          require_eigen_vector_t<T1>* = nullptr,
+          require_eigen_vector_t<T2>* = nullptr>
+Eigen::Matrix<scalar_type_t<T2>, Eigen::Dynamic, 1> algebra_solver_fp(
+    const F& f, const T1& x, const T2& y, const std::vector<double>& dat,
+    const std::vector<int>& dat_int, const std::vector<T_u>& u_scale,
+    const std::vector<T_f>& f_scale, std::ostream* const msgs = nullptr,
+    double function_tolerance = 1e-8, int max_num_steps = 200) {
+  return algebra_solver_fp_impl(algebra_solver_adapter<F>(f), to_ref(x), msgs, u_scale,
+                                f_scale, function_tolerance, max_num_steps, to_ref(y),
+                                dat, dat_int);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/prim/functor/algebra_solver_powell.hpp
+++ b/stan/math/prim/functor/algebra_solver_powell.hpp
@@ -1,0 +1,277 @@
+#ifndef STAN_MATH_PRIM_FUNCTOR_ALGEBRA_SOLVER_POWELL_HPP
+#define STAN_MATH_PRIM_FUNCTOR_ALGEBRA_SOLVER_POWELL_HPP
+
+#include <stan/math/rev/meta.hpp>
+#include <stan/math/rev/core.hpp>
+#include <stan/math/rev/functor/algebra_system.hpp>
+#include <stan/math/prim/err.hpp>
+#include <stan/math/prim/fun/value_of.hpp>
+#include <stan/math/prim/fun/eval.hpp>
+#include <stan/math/prim/functor/apply.hpp>
+#include <stan/math/prim/functor/algebra_solver_adapter.hpp>
+#include <unsupported/Eigen/NonLinearOptimization>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace stan {
+namespace math {
+
+/**
+ * Private interface for calling the Powell solver. Users should call the Powell
+ * solver through `algebra_solver_powell` or `algebra_solver_powell_impl`.
+ *
+ * @tparam F type of equation system function, curried with respect to inputs
+ * @tparam T type of elements in the x vector
+ * @tparam Args types of additional parameters to the equation system functor
+ *
+ * @param[in] f Functor that evaluates the system of equations, curried with
+ *            respect to its input (i.e., "y") values.
+ * @param[in] x Vector of starting values (initial guess).
+ * @param[in, out] msgs the print stream for warning messages.
+ * @param[in] relative_tolerance determines the convergence criteria
+ *            for the solution.
+ * @param[in] function_tolerance determines whether roots are acceptable.
+ * @param[in] max_num_steps  maximum number of function evaluations.
+ * @return theta_dbl Double vector of solutions to the system of equations.
+ * @pre x has size greater than zero.
+ * @pre x has only finite elements.
+ * @pre f returns finite values when passed any value of x and the given args.
+ * @pre relative_tolerance is non-negative.
+ * @pre function_tolerance is non-negative.
+ * @pre max_num_steps is positive.
+ * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
+ * @throw <code>std::domain_error</code> if the norm of the solution exceeds
+ * the function tolerance.
+ */
+template <typename F, typename T, typename... Args,
+          require_eigen_vector_t<T>* = nullptr>
+T& algebra_solver_powell_call_solver(
+    const F& f, T& x, std::ostream* const msgs,
+    const double relative_tolerance, const double function_tolerance,
+    const int64_t max_num_steps, const Args&... args) {
+  // Construct the solver
+  hybrj_functor_solver<decltype(f)> hfs(f);
+  Eigen::HybridNonLinearSolver<decltype(hfs)> solver(hfs);
+
+  // Compute theta_dbl
+  solver.parameters.xtol = relative_tolerance;
+  solver.parameters.maxfev = max_num_steps;
+  solver.solve(x);
+
+  // Check if the max number of steps has been exceeded
+  if (solver.nfev >= max_num_steps) {
+    [&]() STAN_COLD_PATH {
+    throw_domain_error("algebra_solver", "maximum number of iterations",
+                       max_num_steps, "(", ") was exceeded in the solve.");
+    }();
+  }
+
+  // Check solution is a root
+  double system_norm = f(x).stableNorm();
+  if (system_norm > function_tolerance) {
+    [&]() STAN_COLD_PATH {
+    std::ostringstream message;
+    message << "the norm of the algebraic function is " << system_norm
+            << " but should be lower than the function "
+            << "tolerance:";
+    throw_domain_error("algebra_solver", message.str().c_str(),
+                       function_tolerance, "",
+                       ". Consider decreasing the relative tolerance and "
+                       "increasing max_num_steps.");
+    }();
+  }
+
+  return x;
+}
+
+/**
+ * Return the solution to the specified system of algebraic
+ * equations given an initial guess, and parameters and data,
+ * which get passed into the algebraic system.
+ * Use Powell's dogleg solver.
+ *
+ * The user can also specify the relative tolerance
+ * (xtol in Eigen's code), the function tolerance,
+ * and the maximum number of steps (maxfev in Eigen's code).
+ *
+ * This function is overloaded to handle both constant and var-type parameters.
+ * This overload handles non-var parameters, and checks the input and calls the
+ * algebraic solver only.
+ *
+ * @tparam F type of equation system function
+ * @tparam T type of elements in the x vector
+ * @tparam Args types of additional parameters to the equation system functor
+ *
+ * @param[in] f Functor that evaluates the system of equations.
+ * @param[in] x Vector of starting values (initial guess).
+ * @param[in, out] msgs the print stream for warning messages.
+ * @param[in] relative_tolerance determines the convergence criteria
+ *            for the solution.
+ * @param[in] function_tolerance determines whether roots are acceptable.
+ * @param[in] max_num_steps maximum number of function evaluations.
+ * @param[in] args additional parameters to the equation system functor.
+ * @return theta Vector of solutions to the system of equations.
+ * @pre f returns finite values when passed any value of x and the given args.
+ * @throw <code>std::invalid_argument</code> if x has size zero.
+ * @throw <code>std::invalid_argument</code> if x has non-finite elements.
+ * elements.
+ * @throw <code>std::invalid_argument</code> if relative_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
+ * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
+ * @throw <code>std::domain_error</code> if the norm of the solution exceeds
+ * the function tolerance.
+ */
+template <typename F, typename T, typename... Args,
+          require_eigen_vector_t<T>* = nullptr,
+          require_all_st_arithmetic<Args...>* = nullptr>
+Eigen::VectorXd algebra_solver_powell_impl(const F& f, const T& x,
+                                           std::ostream* const msgs,
+                                           const double relative_tolerance,
+                                           const double function_tolerance,
+                                           const int64_t max_num_steps,
+                                           const Args&... args) {
+  const auto& x_ref = to_ref(x);
+  auto x_val = to_ref(value_of(x_ref));
+
+  // Curry the input function w.r.t. y
+  auto f_wrt_x = [&f, msgs, &args...](const auto& x) { return f(x, msgs, args...); };
+
+  check_nonzero_size("algebra_solver_powell", "initial guess", x_val);
+  check_finite("algebra_solver_powell", "initial guess", x_val);
+  check_nonnegative("alegbra_solver_powell", "relative_tolerance",
+                    relative_tolerance);
+  check_nonnegative("algebra_solver_powell", "function_tolerance",
+                    function_tolerance);
+  check_positive("algebra_solver_powell", "max_num_steps", max_num_steps);
+  check_matching_sizes("algebra_solver", "the algebraic system's output",
+                       f_wrt_x(x_ref), "the vector of unknowns, x,", x_ref);
+
+  // Solve the system
+  return algebra_solver_powell_call_solver(f_wrt_x, x_val, msgs,
+                                            relative_tolerance,
+                                            function_tolerance, max_num_steps);
+}
+
+/**
+ * Return the solution to the specified system of algebraic
+ * equations given an initial guess, and parameters and data,
+ * which get passed into the algebraic system.
+ * Use Powell's dogleg solver.
+ *
+ * The user can also specify the relative tolerance
+ * (xtol in Eigen's code), the function tolerance,
+ * and the maximum number of steps (maxfev in Eigen's code).
+ *
+ * Signature to maintain backward compatibility, will be removed
+ * in the future.
+ *
+ * @tparam F type of equation system function
+ * @tparam T1 type of elements in the x vector
+ * @tparam T2 type of elements in the y vector
+ *
+ * @param[in] f Functor that evaluates the system of equations.
+ * @param[in] x Vector of starting values (initial guess).
+ * @param[in] y parameter vector for the equation system.
+ * @param[in] dat continuous data vector for the equation system.
+ * @param[in] dat_int integer data vector for the equation system.
+ * @param[in, out] msgs the print stream for warning messages.
+ * @param[in] relative_tolerance determines the convergence criteria
+ *            for the solution.
+ * @param[in] function_tolerance determines whether roots are acceptable.
+ * @param[in] max_num_steps  maximum number of function evaluations.
+ * @return theta Vector of solutions to the system of equations.
+ * @throw <code>std::invalid_argument</code> if x has size zero.
+ * @throw <code>std::invalid_argument</code> if x has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if y has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if dat_int has non-finite
+ * elements.
+ * @throw <code>std::invalid_argument</code> if relative_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
+ * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
+ * @throw <code>std::domain_error</code> if the norm of the solution exceeds
+ * the function tolerance.
+ */
+template <typename F, typename T1, typename T2,
+          require_all_eigen_vector_t<T1, T2>* = nullptr>
+Eigen::Matrix<value_type_t<T2>, Eigen::Dynamic, 1> algebra_solver_powell(
+    const F& f, const T1& x, const T2& y, const std::vector<double>& dat,
+    const std::vector<int>& dat_int, std::ostream* const msgs = nullptr,
+    const double relative_tolerance = 1e-10,
+    const double function_tolerance = 1e-6,
+    const int64_t max_num_steps = 1e+3) {
+  return algebra_solver_powell_impl(algebra_solver_adapter<F>(f), x, msgs,
+                                    relative_tolerance, function_tolerance,
+                                    max_num_steps, y, dat, dat_int);
+}
+
+/**
+ * Return the solution to the specified system of algebraic
+ * equations given an initial guess, and parameters and data,
+ * which get passed into the algebraic system.
+ * Use Powell's dogleg solver.
+ *
+ * The user can also specify the relative tolerance
+ * (xtol in Eigen's code), the function tolerance,
+ * and the maximum number of steps (maxfev in Eigen's code).
+ *
+ * Signature to maintain backward compatibility, will be removed
+ * in the future.
+ *
+ * @tparam F type of equation system function
+ * @tparam T1 type of elements in the x vector
+ * @tparam T2 type of elements in the y vector
+ *
+ * @param[in] f Functor that evaluates the system of equations.
+ * @param[in] x Vector of starting values (initial guess).
+ * @param[in] y parameter vector for the equation system.
+ * @param[in] dat continuous data vector for the equation system.
+ * @param[in] dat_int integer data vector for the equation system.
+ * @param[in, out] msgs the print stream for warning messages.
+ * @param[in] relative_tolerance determines the convergence criteria
+ *            for the solution.
+ * @param[in] function_tolerance determines whether roots are acceptable.
+ * @param[in] max_num_steps  maximum number of function evaluations.
+ * @return theta Vector of solutions to the system of equations.
+ * @pre f returns finite values when passed any value of x and the given y, dat,
+ *        and dat_int.
+ * @throw <code>std::invalid_argument</code> if x has size zero.
+ * @throw <code>std::invalid_argument</code> if x has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if y has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
+ * @throw <code>std::invalid_argument</code> if dat_int has non-finite
+ * elements.
+ * @throw <code>std::invalid_argument</code> if relative_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
+ * negative.
+ * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
+ * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
+ * <code>std::domain_error</code>) if solver exceeds max_num_steps.
+ * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
+ * <code>std::domain_error</code>) if the norm of the solution exceeds the
+ * function tolerance.
+ */
+template <typename F, typename T1, typename T2,
+          require_all_eigen_vector_t<T1, T2>* = nullptr>
+Eigen::Matrix<value_type_t<T2>, Eigen::Dynamic, 1> algebra_solver(
+    const F& f, const T1& x, const T2& y, const std::vector<double>& dat,
+    const std::vector<int>& dat_int, std::ostream* msgs = nullptr,
+    const double relative_tolerance = 1e-10,
+    const double function_tolerance = 1e-6,
+    const int64_t max_num_steps = 1e+3) {
+  return algebra_solver_powell(f, x, y, dat, dat_int, msgs, relative_tolerance,
+                               function_tolerance, max_num_steps);
+}
+
+}  // namespace math
+}  // namespace stan
+
+#endif

--- a/stan/math/rev/core/chainable_object.hpp
+++ b/stan/math/rev/core/chainable_object.hpp
@@ -62,6 +62,62 @@ auto make_chainable_ptr(T&& obj) {
   return &ptr->get();
 }
 
+/**
+ * `unsafe_chainable_object` hold another object and is useful for connecting
+ * the lifetime of a specific object to the chainable stack. This class
+ * differs from `chainable_object` in that this class does not evaluate
+ * expressions.
+ *
+ * `unsafe_chainable_object` objects should only be allocated with `new`.
+ * `unsafe_chainable_object` objects allocated on the stack will result
+ * in a double free (`obj_` will get destructed once when the
+ * `unsafe_chainable_object` leaves scope and once when the chainable
+ * stack memory is recovered).
+ *
+ * @tparam T type of object to hold
+ */
+template <typename T>
+class unsafe_chainable_object : public chainable_alloc {
+ private:
+  std::decay_t<T> obj_;
+
+ public:
+  /**
+   * Construct chainable object from another object
+   *
+   * @tparam S type of object to hold (must have the same plain type as `T`)
+   */
+  template <typename S,
+            require_same_t<plain_type_t<T>, plain_type_t<S>>* = nullptr>
+  explicit unsafe_chainable_object(S&& obj) : obj_(std::forward<S>(obj)) {}
+
+  /**
+   * Return a reference to the underlying object
+   *
+   * @return reference to underlying object
+   */
+  inline auto& get() noexcept { return obj_; }
+  inline const auto& get() const noexcept { return obj_; }
+};
+
+/**
+ * Store the given object in a `chainable_object` so it is destructed
+ * only when the chainable stack memory is recovered and return
+ * a pointer to the underlying object This function
+ * differs from `make_chainable_object` in that this class does not evaluate
+ * expressions.
+ *
+ * @tparam T type of object to hold
+ * @param obj object to hold
+ * @return pointer to object held in `chainable_object`
+ */
+template <typename T>
+auto make_unsafe_chainable_ptr(T&& obj) {
+  auto ptr = new unsafe_chainable_object<T>(std::forward<T>(obj));
+  return &ptr->get();
+}
+
+
 }  // namespace math
 }  // namespace stan
 #endif

--- a/stan/math/rev/functor/algebra_solver_fp.hpp
+++ b/stan/math/rev/functor/algebra_solver_fp.hpp
@@ -11,6 +11,7 @@
 #include <stan/math/prim/fun/eval.hpp>
 #include <stan/math/prim/functor/apply.hpp>
 #include <stan/math/prim/functor/algebra_solver_adapter.hpp>
+#include <stan/math/prim/functor/algebra_solver_fp.hpp>
 #include <kinsol/kinsol.h>
 #include <sunmatrix/sunmatrix_dense.h>
 #include <sunlinsol/sunlinsol_dense.h>
@@ -22,216 +23,6 @@
 
 namespace stan {
 namespace math {
-
-/**
- * KINSOL algebraic system data holder that handles
- * construction & destruction of SUNDIALS data, as well as
- * auxiliary data that will be used for functor evaluation.
- *
- * @tparam F functor type for system function.
- * @tparam T_u type of scaling vector for unknowns. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- * @tparam T_f type of scaling vector for residual. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- * @tparam Args types of additional parameters to the equation system functor.
- */
-template <typename F, typename T_u, typename T_f, typename... Args>
-struct KinsolFixedPointEnv {
-  /** RHS functor. */
-  const F& f_;
-  /** system size */
-  const size_t N_;
-  /** message stream */
-  std::ostream* msgs_;
-  /** arguments and parameters */
-  std::tuple<const Args&...> args_tuple_;
-  /** KINSOL memory block */
-  void* mem_;
-  /** NVECTOR for unknowns */
-  N_Vector nv_x_;
-  /** NVECTOR for scaling u */
-  N_Vector nv_u_scal_;
-  /** NVECTOR for scaling f */
-  N_Vector nv_f_scal_;
-
-  KinsolFixedPointEnv(const F& f, const Eigen::MatrixXd x,
-                      const std::vector<T_u>& u_scale,
-                      const std::vector<T_f>& f_scale, std::ostream* const msgs,
-                      const Args&... args)
-      : f_(f),
-        N_(x.size()),
-        msgs_(msgs),
-        args_tuple_(args...),
-        mem_(KINCreate()),
-        nv_x_(N_VNew_Serial(N_)),
-        nv_u_scal_(N_VNew_Serial(N_)),
-        nv_f_scal_(N_VNew_Serial(N_)) {
-    for (int i = 0; i < N_; ++i) {
-      NV_Ith_S(nv_x_, i) = stan::math::value_of(x(i));
-      NV_Ith_S(nv_u_scal_, i) = stan::math::value_of(u_scale[i]);
-      NV_Ith_S(nv_f_scal_, i) = stan::math::value_of(f_scale[i]);
-    }
-  }
-
-  ~KinsolFixedPointEnv() {
-    N_VDestroy_Serial(nv_x_);
-    N_VDestroy_Serial(nv_u_scal_);
-    N_VDestroy_Serial(nv_f_scal_);
-    KINFree(&mem_);
-  }
-
-  /** Implements the user-defined function passed to KINSOL. */
-  static int kinsol_f_system(const N_Vector x, const N_Vector f,
-                             void* const user_data) {
-    auto g = static_cast<const KinsolFixedPointEnv<F, T_u, T_f, Args...>*>(
-        user_data);
-    Eigen::VectorXd x_eigen(Eigen::Map<Eigen::VectorXd>(NV_DATA_S(x), g->N_));
-    Eigen::Map<Eigen::VectorXd> f_map(N_VGetArrayPointer(f), g->N_);
-
-    f_map = apply(
-        [&](const auto&... args) { return g->f_(x_eigen, g->msgs_, args...); },
-        g->args_tuple_);
-    return 0;
-  }
-};
-
-/**
- * Private interface for solving fixed point problems using KINSOL. Users should
- * call the KINSOL fixed point solver through `algebra_solver_fp` or
- * `algebra_solver_fp_impl`.
- *
- * @tparam F type of the equation system functor f
- * @tparam T_u type of scaling vector for unknowns. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- * @tparam T_f type of scaling vector for residual. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- * @param x initial point and final solution.
- * @param env KINSOL solution environment
- * @param f_tol Function tolerance
- * @param max_num_steps max nb. of iterations.
- */
-template <typename F, typename T, typename T_u, typename T_f, typename... Args,
-          require_eigen_vector_t<T>* = nullptr>
-Eigen::VectorXd kinsol_solve_fp(const F& f, const T& x,
-                                const double function_tolerance,
-                                const double max_num_steps,
-                                const std::vector<T_u>& u_scale,
-                                const std::vector<T_f>& f_scale,
-                                std::ostream* const msgs, const Args&... args) {
-  KinsolFixedPointEnv<F, T_u, T_f, Args...> env(f, x, u_scale, f_scale, msgs,
-                                                args...);
-  int N = env.N_;
-  void* mem = env.mem_;
-  const int default_anderson_depth = 4;
-  int anderson_depth = std::min(N, default_anderson_depth);
-  Eigen::VectorXd x_solution(N);
-
-  check_flag_sundials(KINSetNumMaxIters(mem, max_num_steps),
-                      "KINSetNumMaxIters");
-  check_flag_sundials(KINSetMAA(mem, anderson_depth), "KINSetMAA");
-  check_flag_sundials(KINInit(mem, &env.kinsol_f_system, env.nv_x_), "KINInit");
-  check_flag_sundials(KINSetFuncNormTol(mem, function_tolerance),
-                      "KINSetFuncNormTol");
-  check_flag_sundials(KINSetUserData(mem, static_cast<void*>(&env)),
-                      "KINSetUserData");
-
-  check_flag_kinsol(
-      KINSol(mem, env.nv_x_, KIN_FP, env.nv_u_scal_, env.nv_f_scal_),
-      max_num_steps);
-
-  for (int i = 0; i < N; i++)
-    x_solution(i) = NV_Ith_S(env.nv_x_, i);
-
-  return x_solution;
-}
-
-/**
- * Return a fixed pointer to the specified system of algebraic
- * equations of form
- * \[
- *   x = F(x; theta)
- * \]
- * given an initial guess \(x\), and parameters \(theta\) and data. Use the
- * KINSOL solver from the SUNDIALS suite.
- *
- * The user can also specify the scaling controls, the function
- * tolerance, and the maximum number of steps.
- *
- * This function is overloaded to handle both constant and var-type parameters.
- * This overload handles var parameters, and checks the input, calls the
- * algebraic solver, and appropriately handles derivative propagation through
- * the `reverse_pass_callback`.
- *
- * @tparam F type of equation system function.
- * @tparam T type of initial guess vector.
- * @tparam T_u type of scaling vector for unknowns. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- * @tparam T_f type of scaling vector for residual. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- *
- * @param[in] f functor that evaluated the system of equations.
- * @param[in] x vector of starting values.
- * @param[in, out] msgs the print stream for warning messages.
- * @param[in] u_scale diagonal scaling matrix elements \(Du\)
- *                    such that \(Du x\) has all components roughly the same
- *                    magnitude when \(x\) is close to a solution.
- *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
- * @param[in] f_scale diagonal scaling matrix elements such
- *                    that \(Df (x - f(x))\) has all components roughly the same
- *                    magnitude when \(x\) is not too close to a solution.
- *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
- * @param[in] function_tolerance Function-norm stopping tolerance.
- * @param[in] max_num_steps maximum number of function evaluations.
- * @param[in] args additional parameters to the equation system functor.
- * @pre f returns finite values when passed any value of x and the given args.
- * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if x has non-finite elements.
- * @throw <code>std::invalid_argument</code> if scaled_step_size is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
- */
-template <typename F, typename T, typename T_u, typename T_f, typename... Args,
-          require_eigen_vector_t<T>* = nullptr,
-          require_all_st_arithmetic<Args...>* = nullptr>
-Eigen::VectorXd algebra_solver_fp_impl(const F& f, const T& x,
-                                       std::ostream* const msgs,
-                                       const std::vector<T_u>& u_scale,
-                                       const std::vector<T_f>& f_scale,
-                                       const double function_tolerance,
-                                       const int max_num_steps,
-                                       const Args&... args) {
-  const auto& x_ref = to_ref(value_of(x));
-
-  check_nonzero_size("algebra_solver_fp", "initial guess", x_ref);
-  check_finite("algebra_solver_fp", "initial guess", x_ref);
-  check_nonnegative("algebra_solver_fp", "u_scale", u_scale);
-  check_nonnegative("algebra_solver_fp", "f_scale", f_scale);
-  check_nonnegative("algebra_solver_fp", "function_tolerance",
-                    function_tolerance);
-  check_positive("algebra_solver_fp", "max_num_steps", max_num_steps);
-  check_matching_sizes("algebra_solver_fp", "the algebraic system's output",
-                       value_of(f(x_ref, msgs, args...)),
-                       "the vector of unknowns, x,", x_ref);
-
-  return kinsol_solve_fp(f, x_ref, function_tolerance, max_num_steps, u_scale,
-                         f_scale, msgs, args...);
-}
 
 /**
  * Return a fixed pointer to the specified system of algebraic
@@ -318,24 +109,24 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_fp_impl(
     const std::vector<T_u>& u_scale, const std::vector<T_f>& f_scale,
     const double function_tolerance, const int max_num_steps,
     const Args&... args) {
-  const auto& x_val = to_ref(value_of(x));
   auto arena_args_tuple = std::make_tuple(to_arena(args)...);
+
   auto args_vals_tuple = apply(
-      [&](const auto&... args) {
-        return std::make_tuple(to_ref(value_of(args))...);
-      },
+      [](const auto&... args) { return std::make_tuple(value_of(args)...); },
       arena_args_tuple);
 
-  auto f_wrt_x = [&](const auto& x) {
-    return apply([&](const auto&... args) { return f(x, msgs, args...); },
-                 args_vals_tuple);
+  auto f_wrt_x = [&msgs, &f, &args_vals_tuple](const auto& x) {
+    return apply(
+        [&x, &msgs, &f](const auto&... args) { return f(x, msgs, args...); },
+        args_vals_tuple);
   };
 
   // FP solution
   Eigen::VectorXd theta_dbl = apply(
-      [&](const auto&... vals) {
-        return kinsol_solve_fp(f, x_val, function_tolerance, max_num_steps,
-                               u_scale, f_scale, msgs, vals...);
+      [&f, function_tolerance, &u_scale, &f_scale, &msgs,
+        max_num_steps, x_val = value_of(x)](const auto&... vals) {
+        return kinsol_solve_fp(f, x_val, function_tolerance,
+                               max_num_steps, u_scale, f_scale, msgs, vals...);
       },
       args_vals_tuple);
 
@@ -343,27 +134,23 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_fp_impl(
   Eigen::VectorXd f_x;
 
   jacobian(f_wrt_x, theta_dbl, f_x, Jf_x);
-  int N = x.size();
-  Jf_x = Eigen::MatrixXd::Identity(x.size(), x.size()) - Jf_x;
 
   using ret_type = Eigen::Matrix<var, Eigen::Dynamic, -1>;
-  auto arena_Jf_x = to_arena(Jf_x);
-
   arena_t<ret_type> ret = theta_dbl;
 
-  reverse_pass_callback([f, ret, arena_args_tuple, arena_Jf_x, msgs]() mutable {
+  auto Jf_xT_lu_ptr
+      = make_unsafe_chainable_ptr((Eigen::MatrixXd::Identity(x.size(), x.size()) - Jf_x).transpose().eval().partialPivLu());  // Lu
+
+  reverse_pass_callback([f, ret, arena_args_tuple, Jf_xT_lu_ptr, msgs]() mutable {
     // Contract specificities with inverse Jacobian of f with respect to x.
-    Eigen::VectorXd ret_adj = ret.adj();
-    Eigen::VectorXd eta = arena_Jf_x.transpose().lu().solve(ret_adj);
+    Eigen::VectorXd eta = Jf_xT_lu_ptr->solve(ret.adj().eval());
 
     // Contract with Jacobian of f with respect to y using a nested reverse
     // autodiff pass.
     {
       nested_rev_autodiff rev;
-
-      Eigen::VectorXd ret_val = ret.val();
       auto x_nrad_ = apply(
-          [&](const auto&... args) { return eval(f(ret_val, msgs, args...)); },
+          [&](const auto&... args) { return eval(f(ret.val(), msgs, args...)); },
           arena_args_tuple);
       x_nrad_.adj() = eta;
       grad();
@@ -371,78 +158,6 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_fp_impl(
   });
 
   return ret_type(ret);
-}
-
-/**
- * Return a fixed pointer to the specified system of algebraic
- * equations of form
- *
- * x = F(x; theta)
- *
- * given an initial guess x, and parameters theta and data. Use the
- * KINSOL solver from the SUNDIALS suite.
- *
- * The user can also specify the scaling controls, the function
- * tolerance, and the maximum number of steps.
- *
- * Signature to maintain backward compatibility, will be removed
- * in the future.
- *
- * @tparam F type of equation system function.
- * @tparam T type of initial guess vector. The final solution
- *           type doesn't depend on initial guess type,
- *           but we allow initial guess to be either data or param.
- * @tparam T_u type of scaling vector for unknowns. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- * @tparam T_f type of scaling vector for residual. We allow
- *             it to be @c var because scaling could be parameter
- *             dependent. Internally these params are converted to data
- *             because scaling is applied.
- *
- * @param[in] f Functor that evaluated the system of equations.
- * @param[in] x Vector of starting values.
- * @param[in] y Parameter vector for the equation system. The function
- *            is overloaded to treat y as a vector of doubles or of a
- *            a template type T.
- * @param[in] dat Continuous data vector for the equation system.
- * @param[in] dat_int Integer data vector for the equation system.
- * @param[in, out] msgs The print stream for warning messages.
- * @param[in] u_scale diagonal scaling matrix elements Du
- *                    such that Du*x has all components roughly the same
- *                    magnitude when x is close to a solution.
- *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
- * @param[in] f_scale diagonal scaling matrix elements such
- *                    that Df*(x-f(x)) has all components roughly the same
- *                    magnitude when x is not too close to a solution.
- *                    (ref. KINSOL user guide chap.2 sec. "Scaling")
- * @param[in] f_tol Function-norm stopping tolerance.
- * @param[in] max_num_steps maximum number of function evaluations.
- * @pre f returns finite values when passed any value of x and the given y, dat,
- *        and dat_int.
- * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if x has non-finite elements.
- * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
- * @throw <code>std::invalid_argument</code> if dat_int has non-finite elements.
- * @throw <code>std::invalid_argument</code> if scaled_step_size is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::runtime_error</code>) if solver exceeds max_num_steps.
- */
-template <typename F, typename T1, typename T2, typename T_u, typename T_f>
-Eigen::Matrix<scalar_type_t<T2>, Eigen::Dynamic, 1> algebra_solver_fp(
-    const F& f, const Eigen::Matrix<T1, -1, 1>& x,
-    const Eigen::Matrix<T2, -1, 1>& y, const std::vector<double>& dat,
-    const std::vector<int>& dat_int, const std::vector<T_u>& u_scale,
-    const std::vector<T_f>& f_scale, std::ostream* const msgs = nullptr,
-    double function_tolerance = 1e-8, int max_num_steps = 200) {
-  return algebra_solver_fp_impl(algebra_solver_adapter<F>(f), x, msgs, u_scale,
-                                f_scale, function_tolerance, max_num_steps, y,
-                                dat, dat_int);
 }
 
 }  // namespace math

--- a/stan/math/rev/functor/algebra_solver_powell.hpp
+++ b/stan/math/rev/functor/algebra_solver_powell.hpp
@@ -9,6 +9,7 @@
 #include <stan/math/prim/fun/eval.hpp>
 #include <stan/math/prim/functor/apply.hpp>
 #include <stan/math/prim/functor/algebra_solver_adapter.hpp>
+#include <stan/math/prim/functor/algebra_solver_powell.hpp>
 #include <unsupported/Eigen/NonLinearOptimization>
 #include <iostream>
 #include <string>
@@ -16,141 +17,6 @@
 
 namespace stan {
 namespace math {
-
-/**
- * Private interface for calling the Powell solver. Users should call the Powell
- * solver through `algebra_solver_powell` or `algebra_solver_powell_impl`.
- *
- * @tparam F type of equation system function, curried with respect to inputs
- * @tparam T type of elements in the x vector
- * @tparam Args types of additional parameters to the equation system functor
- *
- * @param[in] f Functor that evaluates the system of equations, curried with
- *            respect to its input (i.e., "y") values.
- * @param[in] x Vector of starting values (initial guess).
- * @param[in, out] msgs the print stream for warning messages.
- * @param[in] relative_tolerance determines the convergence criteria
- *            for the solution.
- * @param[in] function_tolerance determines whether roots are acceptable.
- * @param[in] max_num_steps  maximum number of function evaluations.
- * @return theta_dbl Double vector of solutions to the system of equations.
- * @pre x has size greater than zero.
- * @pre x has only finite elements.
- * @pre f returns finite values when passed any value of x and the given args.
- * @pre relative_tolerance is non-negative.
- * @pre function_tolerance is non-negative.
- * @pre max_num_steps is positive.
- * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
- * @throw <code>std::domain_error</code> if the norm of the solution exceeds
- * the function tolerance.
- */
-template <typename F, typename T, typename... Args,
-          require_eigen_vector_t<T>* = nullptr>
-Eigen::VectorXd algebra_solver_powell_call_solver_(
-    const F& f, const T& x, std::ostream* const msgs,
-    const double relative_tolerance, const double function_tolerance,
-    const int64_t max_num_steps, const Args&... args) {
-  // Construct the solver
-  hybrj_functor_solver<decltype(f)> hfs(f);
-  Eigen::HybridNonLinearSolver<decltype(hfs)> solver(hfs);
-
-  // Compute theta_dbl
-  Eigen::VectorXd theta_dbl = x;
-  solver.parameters.xtol = relative_tolerance;
-  solver.parameters.maxfev = max_num_steps;
-  solver.solve(theta_dbl);
-
-  // Check if the max number of steps has been exceeded
-  if (solver.nfev >= max_num_steps) {
-    throw_domain_error("algebra_solver", "maximum number of iterations",
-                       max_num_steps, "(", ") was exceeded in the solve.");
-  }
-
-  // Check solution is a root
-  double system_norm = f(theta_dbl).stableNorm();
-  if (system_norm > function_tolerance) {
-    std::ostringstream message;
-    message << "the norm of the algebraic function is " << system_norm
-            << " but should be lower than the function "
-            << "tolerance:";
-    throw_domain_error("algebra_solver", message.str().c_str(),
-                       function_tolerance, "",
-                       ". Consider decreasing the relative tolerance and "
-                       "increasing max_num_steps.");
-  }
-
-  return theta_dbl;
-}
-
-/**
- * Return the solution to the specified system of algebraic
- * equations given an initial guess, and parameters and data,
- * which get passed into the algebraic system.
- * Use Powell's dogleg solver.
- *
- * The user can also specify the relative tolerance
- * (xtol in Eigen's code), the function tolerance,
- * and the maximum number of steps (maxfev in Eigen's code).
- *
- * This function is overloaded to handle both constant and var-type parameters.
- * This overload handles non-var parameters, and checks the input and calls the
- * algebraic solver only.
- *
- * @tparam F type of equation system function
- * @tparam T type of elements in the x vector
- * @tparam Args types of additional parameters to the equation system functor
- *
- * @param[in] f Functor that evaluates the system of equations.
- * @param[in] x Vector of starting values (initial guess).
- * @param[in, out] msgs the print stream for warning messages.
- * @param[in] relative_tolerance determines the convergence criteria
- *            for the solution.
- * @param[in] function_tolerance determines whether roots are acceptable.
- * @param[in] max_num_steps maximum number of function evaluations.
- * @param[in] args additional parameters to the equation system functor.
- * @return theta Vector of solutions to the system of equations.
- * @pre f returns finite values when passed any value of x and the given args.
- * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if x has non-finite elements.
- * elements.
- * @throw <code>std::invalid_argument</code> if relative_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
- * @throw <code>std::domain_error</code> if the norm of the solution exceeds
- * the function tolerance.
- */
-template <typename F, typename T, typename... Args,
-          require_eigen_vector_t<T>* = nullptr,
-          require_all_st_arithmetic<Args...>* = nullptr>
-Eigen::VectorXd algebra_solver_powell_impl(const F& f, const T& x,
-                                           std::ostream* const msgs,
-                                           const double relative_tolerance,
-                                           const double function_tolerance,
-                                           const int64_t max_num_steps,
-                                           const Args&... args) {
-  const auto& x_val = to_ref(value_of(x));
-
-  // Curry the input function w.r.t. y
-  auto f_wrt_x = [&](const auto& x) { return f(x, msgs, args...); };
-
-  check_nonzero_size("algebra_solver_powell", "initial guess", x_val);
-  check_finite("algebra_solver_powell", "initial guess", x_val);
-  check_nonnegative("alegbra_solver_powell", "relative_tolerance",
-                    relative_tolerance);
-  check_nonnegative("algebra_solver_powell", "function_tolerance",
-                    function_tolerance);
-  check_positive("algebra_solver_powell", "max_num_steps", max_num_steps);
-  check_matching_sizes("algebra_solver", "the algebraic system's output",
-                       f_wrt_x(x), "the vector of unknowns, x,", x);
-
-  // Solve the system
-  return algebra_solver_powell_call_solver_(f_wrt_x, x_val, msgs,
-                                            relative_tolerance,
-                                            function_tolerance, max_num_steps);
-}
 
 /**
  * Return the solution to the specified system of algebraic
@@ -222,7 +88,8 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_powell_impl(
     const F& f, const T& x, std::ostream* const msgs,
     const double relative_tolerance, const double function_tolerance,
     const int64_t max_num_steps, const T_Args&... args) {
-  const auto& x_val = to_ref(value_of(x));
+  const auto& x_ref = to_ref(x);
+  auto x_val = to_ref(value_of(x_ref));
   auto arena_args_tuple = std::make_tuple(to_arena(args)...);
   auto args_vals_tuple = apply(
       [&](const auto&... args) {
@@ -231,8 +98,8 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_powell_impl(
       arena_args_tuple);
 
   // Curry the input function w.r.t. y
-  auto f_wrt_x = [&](const auto& x) {
-    return apply([&](const auto&... args) { return f(x, msgs, args...); },
+  auto f_wrt_x = [&args_vals_tuple, &f, msgs](const auto& x) {
+    return apply([&x, &f, msgs](const auto&... args) { return f(x, msgs, args...); },
                  args_vals_tuple);
   };
 
@@ -244,29 +111,28 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_powell_impl(
                     function_tolerance);
   check_positive("algebra_solver_powell", "max_num_steps", max_num_steps);
   check_matching_sizes("algebra_solver", "the algebraic system's output",
-                       f_wrt_x(x), "the vector of unknowns, x,", x);
+                       f_wrt_x(x_ref), "the vector of unknowns, x,", x_ref);
 
   // Solve the system
-  Eigen::VectorXd theta_dbl = algebra_solver_powell_call_solver_(
+  algebra_solver_powell_call_solver(
       f_wrt_x, x_val, msgs, relative_tolerance, function_tolerance,
       max_num_steps);
 
   Eigen::MatrixXd Jf_x;
   Eigen::VectorXd f_x;
 
-  jacobian(f_wrt_x, theta_dbl, f_x, Jf_x);
+  jacobian(f_wrt_x, x_val, f_x, Jf_x);
 
   using ret_type = Eigen::Matrix<var, Eigen::Dynamic, -1>;
   auto Jf_xT_lu_ptr
-      = make_chainable_ptr(Jf_x.transpose().fullPivHouseholderQr());  // Lu
+      = make_unsafe_chainable_ptr(Jf_x.transpose().partialPivLu());  // Lu
 
-  arena_t<ret_type> ret = theta_dbl;
+  arena_t<ret_type> ret = x_val;
 
   reverse_pass_callback([f, ret, arena_args_tuple, Jf_xT_lu_ptr,
                          msgs]() mutable {
     // Contract specificities with inverse Jacobian of f with respect to x.
-    Eigen::VectorXd ret_adj = ret.adj();
-    Eigen::VectorXd eta = -Jf_xT_lu_ptr->solve(ret_adj);
+    Eigen::VectorXd eta = -Jf_xT_lu_ptr->solve(ret.adj().eval());
 
     // Contract with Jacobian of f with respect to y using a nested reverse
     // autodiff pass.
@@ -282,121 +148,6 @@ Eigen::Matrix<var, Eigen::Dynamic, 1> algebra_solver_powell_impl(
   });
 
   return ret_type(ret);
-}
-
-/**
- * Return the solution to the specified system of algebraic
- * equations given an initial guess, and parameters and data,
- * which get passed into the algebraic system.
- * Use Powell's dogleg solver.
- *
- * The user can also specify the relative tolerance
- * (xtol in Eigen's code), the function tolerance,
- * and the maximum number of steps (maxfev in Eigen's code).
- *
- * Signature to maintain backward compatibility, will be removed
- * in the future.
- *
- * @tparam F type of equation system function
- * @tparam T1 type of elements in the x vector
- * @tparam T2 type of elements in the y vector
- *
- * @param[in] f Functor that evaluates the system of equations.
- * @param[in] x Vector of starting values (initial guess).
- * @param[in] y parameter vector for the equation system.
- * @param[in] dat continuous data vector for the equation system.
- * @param[in] dat_int integer data vector for the equation system.
- * @param[in, out] msgs the print stream for warning messages.
- * @param[in] relative_tolerance determines the convergence criteria
- *            for the solution.
- * @param[in] function_tolerance determines whether roots are acceptable.
- * @param[in] max_num_steps  maximum number of function evaluations.
- * @return theta Vector of solutions to the system of equations.
- * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if x has non-finite elements.
- * @throw <code>std::invalid_argument</code> if y has non-finite elements.
- * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
- * @throw <code>std::invalid_argument</code> if dat_int has non-finite
- * elements.
- * @throw <code>std::invalid_argument</code> if relative_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>std::domain_error</code> solver exceeds max_num_steps.
- * @throw <code>std::domain_error</code> if the norm of the solution exceeds
- * the function tolerance.
- */
-template <typename F, typename T1, typename T2,
-          require_all_eigen_vector_t<T1, T2>* = nullptr>
-Eigen::Matrix<value_type_t<T2>, Eigen::Dynamic, 1> algebra_solver_powell(
-    const F& f, const T1& x, const T2& y, const std::vector<double>& dat,
-    const std::vector<int>& dat_int, std::ostream* const msgs = nullptr,
-    const double relative_tolerance = 1e-10,
-    const double function_tolerance = 1e-6,
-    const int64_t max_num_steps = 1e+3) {
-  return algebra_solver_powell_impl(algebra_solver_adapter<F>(f), x, msgs,
-                                    relative_tolerance, function_tolerance,
-                                    max_num_steps, y, dat, dat_int);
-}
-
-/**
- * Return the solution to the specified system of algebraic
- * equations given an initial guess, and parameters and data,
- * which get passed into the algebraic system.
- * Use Powell's dogleg solver.
- *
- * The user can also specify the relative tolerance
- * (xtol in Eigen's code), the function tolerance,
- * and the maximum number of steps (maxfev in Eigen's code).
- *
- * Signature to maintain backward compatibility, will be removed
- * in the future.
- *
- * @tparam F type of equation system function
- * @tparam T1 type of elements in the x vector
- * @tparam T2 type of elements in the y vector
- *
- * @param[in] f Functor that evaluates the system of equations.
- * @param[in] x Vector of starting values (initial guess).
- * @param[in] y parameter vector for the equation system.
- * @param[in] dat continuous data vector for the equation system.
- * @param[in] dat_int integer data vector for the equation system.
- * @param[in, out] msgs the print stream for warning messages.
- * @param[in] relative_tolerance determines the convergence criteria
- *            for the solution.
- * @param[in] function_tolerance determines whether roots are acceptable.
- * @param[in] max_num_steps  maximum number of function evaluations.
- * @return theta Vector of solutions to the system of equations.
- * @pre f returns finite values when passed any value of x and the given y, dat,
- *        and dat_int.
- * @throw <code>std::invalid_argument</code> if x has size zero.
- * @throw <code>std::invalid_argument</code> if x has non-finite elements.
- * @throw <code>std::invalid_argument</code> if y has non-finite elements.
- * @throw <code>std::invalid_argument</code> if dat has non-finite elements.
- * @throw <code>std::invalid_argument</code> if dat_int has non-finite
- * elements.
- * @throw <code>std::invalid_argument</code> if relative_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if function_tolerance is strictly
- * negative.
- * @throw <code>std::invalid_argument</code> if max_num_steps is not positive.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::domain_error</code>) if solver exceeds max_num_steps.
- * @throw <code>boost::math::evaluation_error</code> (which is a subclass of
- * <code>std::domain_error</code>) if the norm of the solution exceeds the
- * function tolerance.
- */
-template <typename F, typename T1, typename T2,
-          require_all_eigen_vector_t<T1, T2>* = nullptr>
-Eigen::Matrix<value_type_t<T2>, Eigen::Dynamic, 1> algebra_solver(
-    const F& f, const T1& x, const T2& y, const std::vector<double>& dat,
-    const std::vector<int>& dat_int, std::ostream* msgs = nullptr,
-    const double relative_tolerance = 1e-10,
-    const double function_tolerance = 1e-6,
-    const int64_t max_num_steps = 1e+3) {
-  return algebra_solver_powell(f, x, y, dat, dat_int, msgs, relative_tolerance,
-                               function_tolerance, max_num_steps);
 }
 
 }  // namespace math

--- a/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
+++ b/test/unit/math/rev/functor/algebra_solver_fp_test.cpp
@@ -1,7 +1,7 @@
 #include <stan/math/rev.hpp>
-#include <stan/math/prim.hpp>
 #include <test/unit/math/rev/fun/util.hpp>
 #include <test/unit/math/rev/functor/util_algebra_solver.hpp>
+#include <stan/math/prim.hpp>
 #include <test/unit/util.hpp>
 #include <gtest/gtest.h>
 #include <iostream>


### PR DESCRIPTION
- Moves arithmetic only solver versions to prim/functor
- Makes make_unsafe_chainable_ptr() for handling the partial pivot LU
- Reduces the memory usage in the solvers
- General cleanup

